### PR TITLE
Run vr-test for a single component for both PC and SP by one command

### DIFF
--- a/.scripts/vr-test.sh
+++ b/.scripts/vr-test.sh
@@ -1,0 +1,1 @@
+wdio run ./wdio/chrome.conf.js --spec $1 && wdio run ./wdio/sp.chrome.conf.js --spec $1

--- a/README.md
+++ b/README.md
@@ -250,6 +250,12 @@ npm run test:chrome src/components/<component-name>/stories/vr-test/index.spec.t
 npm run test:chrome:sp src/components/<component-name>/stories/vr-test/index.spec.ts
 ```
 
+**Both Desktop and Smartphone**
+
+```bash
+npm test src/components/<component-name>/stories/vr-test/index.spec.ts
+```
+
 **Run all tests**
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:chrome:sp": "wdio run ./wdio/sp.chrome.conf.js --spec",
     "test:firefox": "wdio run ./wdio/firefox.conf.js --spec",
     "test:firefox:sp": "wdio run ./wdio/sp.firefox.conf.js --spec",
-    "test": "npm run test:chrome && npm run test:chrome:sp"
+    "test": "./.scripts/vr-test.sh"
   },
   "keywords": [
     "storybook",


### PR DESCRIPTION
WHAT:
- This PR improves `npm test` command by hooking it to a manual script

WHY:
- We can only run vr-test for a single component for only PC or SP. So if we want to test a single component for both devices, we have to run 2 separated commands.
- This PR makes it simple by only one command
`npm test [args]` 
with args here can be a component path or empty. If args is empty, this performs all tests (like it does before)

`npm test`  => Test all
`npm test src/components/<component-name>/stories/vr-test/index.spec.ts`  => Test only one component for both PC and SP

HOW:
- Take a look at `.scripts/vr-test.sh`. It's simple ;)