### PR TITLE
Update @types/node dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2174,9 +2174,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-      "integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ==",
+      "version": "12.12.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.27.tgz",
+      "integrity": "sha512-odQFl/+B9idbdS0e8IxDl2ia/LP8KZLXhV3BUeI98TrZp0uoIzQPhGd+5EtzHmT0SMOIaPd7jfz6pOHLWTtl7A==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/ip": "^1.1.0",
     "@types/jest": "^24.0.18",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.7.12",
+    "@types/node": "^12.12.27",
     "@types/storybook__react": "^4.0.2",
     "@typescript-eslint/eslint-plugin": "^2.12.0",
     "@typescript-eslint/parser": "^2.12.0",


### PR DESCRIPTION
Some files using node.js (for example: stories.tsx) were showing the red underline Typescript errors. I updated the @types/node dev dependency to resolve this issue.